### PR TITLE
Fixed checkboxes in IE

### DIFF
--- a/blocks/checkbox/checkbox.styl
+++ b/blocks/checkbox/checkbox.styl
@@ -7,23 +7,23 @@
 .nb-checkbox_disabled
   skin: disabled
 
-.nb-checkbox__input
-  kind: hidden visually
+if !ie
+  .nb-checkbox__input
+    kind: hidden visually
 
-.nb-checkbox__flag_type_radio
+  .nb-checkbox__flag_type_radio
     kind: icon
     skin: radio (-icon '& > .nb-checkbox__flag__icon')
 
-.nb-checkbox__flag_type_checkbox
-  kind: icon
-  skin: checkbox (-icon '& > .nb-checkbox__flag__icon')
+  .nb-checkbox__flag_type_checkbox
+    kind: icon
+    skin: checkbox (-icon '& > .nb-checkbox__flag__icon')
 
+  .nb-checkbox__input:checked + .nb-checkbox__flag
+    skin: button_checked
 
-.nb-checkbox__input:checked + .nb-checkbox__flag
-  skin: button_checked
-
-.nb-checkbox__input:focus + .nb-checkbox__flag
-  skin: button_focus
+  .nb-checkbox__input:focus + .nb-checkbox__flag
+    skin: button_focus
 
 .nb-checkbox_size_s,
 .nb-checkbox_size_s .nb-checkbox__flag


### PR DESCRIPTION
Subj: now in IE < 9 checkboxes and radios would fall back to normal browser ones. @basvasilich, could you look at it and release?
