### PR TITLE
Атритуб title для инпута в случае с кнопкой загрузки

### DIFF
--- a/blocks/button/button.yate
+++ b/blocks/button/button.yate
@@ -107,6 +107,9 @@ match .buttonAttach nb {
                     if .attrs.name {
                         @name = "{.attrs.name}"
                     }
+                    if .attrs.title {
+                        @title += "{.attrs.title}"
+                    }
                 </input>
                 <span class="nb-file-intruder__focus"></span>
             </span>

--- a/demo/buttons.yate
+++ b/demo/buttons.yate
@@ -99,6 +99,9 @@ func attach-button() {
             'myclass2'
         ]
         'type': 'file'
+        'attrs': {
+            'title': 'Выберите файл'
+        }
     })
 }
 


### PR DESCRIPTION
Иногда необходимо добавить атрибут тайтл для `input`, в случае кнопки загрузки файла.

```
nb-button({
  'content': 'Прикрепить файл'
  'type': 'file'
  'attrs': {
    'title': 'Выберите файл'
  }
})
```
