### PR TITLE
nb-select_changed event

### DIFF
--- a/blocks/select/select.js
+++ b/blocks/select/select.js
@@ -148,6 +148,7 @@ nb.define('select', {
          *     text: '..'
          *     value: '..'
          * }
+     * @fires 'nb-select_changed'
      */
     setValue: function (params) {
         this.value = params.value;
@@ -156,7 +157,9 @@ nb.define('select', {
 
 
         this.$selected = this.$fallback.children('[value="' + this.value + '"]').attr('selected', 'selected');
-        this.button.setText(this.text)
+        this.button.setText(this.text);
+
+        this.trigger('nb-select_changed');
 
         this.$fallback.val(params.value);
         return this


### PR DESCRIPTION
Add `nb-event_changed` event firing when `setValue` method called

```
var select = nb.block(node);

select.on('nb-select_changed', handler);
```
