### PR TITLE
nb.checkbox: возможность задавать собственную верстку в label

### DIFF
--- a/blocks/checkbox/checkbox.yate
+++ b/blocks/checkbox/checkbox.yate
@@ -46,7 +46,16 @@ match .checkbox nb {
         <span class="nb-checkbox__flag nb-checkbox__flag_type_{ .type }"><span class="nb-checkbox__flag__icon"></span></span>
 
         <span class="nb-checkbox__label">
-            .text
+            if (.text-id) {
+                labelRoot = {
+                    'checkbox-label': .text-id
+                }
+
+                apply labelRoot nb-checkbox-label
+
+            } else {
+                .text
+            }
         </span>
     </label>
 }

--- a/unittests/index.html
+++ b/unittests/index.html
@@ -43,6 +43,7 @@
 
     <script src="spec/button.js"></script>
     <script src="spec/checkbox.js"></script>
+    <script src="spec/checkbox-html.js"></script>
     <script src="spec/select.js"></script>
     <script src="spec/input.js"></script>
     <script src="spec/toggler.js"></script>

--- a/unittests/spec/checkbox-html.js
+++ b/unittests/spec/checkbox-html.js
@@ -1,0 +1,20 @@
+describe("Checkbox HTML Tests", function() {
+
+    describe("checkbox with custom html label", function() {
+
+        beforeEach(function() {
+            this.checkbox = nb.find('checkbox-with-html-label');
+        });
+
+        afterEach(function() {
+            delete this.checkbox;
+        });
+
+        it('should has custom html for label', function() {
+            var label = this.checkbox.$node.find('.nb-checkbox__label')[0].outerHTML;
+            expect(label).to.be.equal('<span class="nb-checkbox__label"><span>1</span></span>');
+        });
+
+    });
+
+});

--- a/unittests/tests.yate
+++ b/unittests/tests.yate
@@ -30,6 +30,11 @@ match / {
         "id": "checkbox-disabled"
     })
 
+    nb-checkbox({
+        "text-id": 'uniq-str'
+        "id": "checkbox-with-html-label"
+    })
+
      nb-checkbox({
             "attrs": {
                 "value": "my-value"
@@ -90,4 +95,10 @@ match / {
         "checked": true()
         "id": "toggler-checked"
     })
+}
+
+match .*[.checkbox-label == 'uniq-str'] nb-checkbox-label {
+    <span>
+        "1"
+    </span>
 }


### PR DESCRIPTION
**Это не реализация! Это прототип идеи**

В общем виде требуется иметь возможность задавать собственную верстку для `nb-checkbox__label`, чтобы уметь делать вот так

``` (html)
<label class="nb-checkbox">
  <input type="checbox" class="nb-checkbox__input"/>
  <span class="nb-checkbox__label">
    <!-- вот тут кастомная верстка --> 
    <span class="my-block-email'>doochik@ya.ru</span>
    <span class="my-block-name'>Aleksei Androsov</span>
  </span>
</label>
```

Базовая концепция выглядит так:
1. Вместо `text` в параметрах чекбокса передается `text-id`. `text-id` - уникальная строка, чтобы иметь возможность найти нужный label среди многих чекбоксов
2. При генерации чекбокса для label создается новый рут с этим text-id и вызывается на него apply
3. В пользовательском шаблоне можно сделать матч на фиксированную моду `nb-checkbox-label` и этот уникальный id

Проблемы:
1. Не очень явное решение
2. Не понятно, что делать, если label'ы надо генерировать динамически из данных
