### PR TITLE
Fix undefined content

### DIFF
--- a/blocks/button/button.yate
+++ b/blocks/button/button.yate
@@ -117,7 +117,9 @@ match .buttonAttach nb {
         </span>
         <span class="nb-button__text">
             apply .icon nb
-            html(.content)
+            if (.content) {
+                html(.content)
+            }
         </span>
     </label>
 }

--- a/blocks/checkbox/checkbox.yate
+++ b/blocks/checkbox/checkbox.yate
@@ -46,7 +46,9 @@ match .checkbox nb {
         <span class="nb-checkbox__flag nb-checkbox__flag_type_{ .type }"><span class="nb-checkbox__flag__icon"></span></span>
 
         <span class="nb-checkbox__label">
-            html(.content)
+            if (.content) {
+                html(.content)
+            }
         </span>
     </label>
 }

--- a/blocks/radio-button/radio-button.yate
+++ b/blocks/radio-button/radio-button.yate
@@ -50,7 +50,9 @@ match .radio-button nb {
 
                     <span class="nb-button__text">
                             apply .icon nb
-                            html(.content)
+                            if (.content) {
+                                html(.content)
+                            }
                     </span>
                 </label>
             </span>


### PR DESCRIPTION
If `content` field is not defined (e.g. for button only with icon) there is undefined text instead of empty
