### PR TITLE
Added sticky positioning for headers in demo

### DIFF
--- a/demo/demo.css
+++ b/demo/demo.css
@@ -37,6 +37,10 @@ body
 
 .demo-pane__desc
 {
+    position: -webkit-sticky;
+    position: sticky;
+    top: 0;
+
     float: left;
     width: 150px;
 }


### PR DESCRIPTION
Just for fun and for headers to be always on the screen in the demo. Need [this flag](chrome://flags/#enable-experimental-web-platform-features) to be turned on in webkits.
