### PR TITLE
Fixing the baseline alignment for selects

### DIFF
--- a/blocks/select/select.styl
+++ b/blocks/select/select.styl
@@ -16,6 +16,18 @@
     padding-right: 4px
     margin-right: - @padding-right
 
+    float: left // For baseline alignment
+
+// For baseline alignment,
+// TODO: move to Stylobate
+.nb-select-helper
+  display: inline-block
+  width: 0
+  overflow: hidden
+
+  &:before
+    content: " "
+
 .nb-select .nb-select__button
   box-sizing: border-box
   display: inline-block

--- a/blocks/select/select.yate
+++ b/blocks/select/select.yate
@@ -28,6 +28,7 @@ match .select nb {
                 }
               }
           </span>
+          <span class="nb-select-helper"></span> // Helper for baseline alignment
           <select id="nb-select_{ .id }" class="nb-select__fallback">
                 if ( .disabled ) {
                     @disabled = 'disabled'

--- a/demo/select.yate
+++ b/demo/select.yate
@@ -96,6 +96,7 @@ func select-medium() {
           }
       ]
     })
+    " Текст рядом с селектами"
 }
 func select-small() {
     block = {
@@ -123,6 +124,7 @@ func select-small() {
         ]
     }
     nb-select(block)
+    " Текст рядом с селектами"
 }
 
 //func select-disable() {


### PR DESCRIPTION
As the buttons inside select have `overflow: hidden`, we need to move this block to another flow and add a proper inline one.
