### PR TITLE
Fix popup-toggler js error

### DIFF
--- a/blocks/popup/popup.js
+++ b/blocks/popup/popup.js
@@ -475,10 +475,15 @@
 nb.define('popup-toggler', {
 
     events: {
+        'init': 'oninit',
         'click': 'onclick'
     },
 
-    'onclick': function() {
+    oninit: function() {
+        this.$node = $(this.node);
+    },
+
+    onclick: function() {
         if (this.$node.hasClass('is-disabled')) {
             return;
         }


### PR DESCRIPTION
There is no `$node` property for block instance by default :)
