### PR TITLE
Adds overlay for static popup

### DIFF
--- a/blocks/paranja/paranja.yate
+++ b/blocks/paranja/paranja.yate
@@ -7,7 +7,7 @@ func nb-paranja(nodeset options) {
 }
 
 match .paranja nb {
-    <div class="nb-paranja nb-paranja_theme_{ .theme }" data-nb='paranja'>
+    <div class="nb-paranja nb-paranja_theme_{ .theme }">
         apply . nb-main-attrs
         
         if .content {

--- a/blocks/popup/popup.yate
+++ b/blocks/popup/popup.yate
@@ -90,6 +90,9 @@ func nb-popup-modal(nodeset options) {
 }
 
 match .modalPopup nb {
+    if .static {
+        nb-paranja()
+    }
     <div class="nb-popup nb-popup_type_modal">
         if !.static {
             @data-nb = "popup"


### PR DESCRIPTION
- remove `data-nb` for nb-paranjs 'cause there is no more nanoblock's declaration
- adds overlay when popup is static (static is false by default so jUI dialog cares about it)
