### PR TITLE
При вызове enable/disable селекта, мы должны вызывать enable/disable jUI-автокомплита

### DIFF
--- a/blocks/select/select.js
+++ b/blocks/select/select.js
@@ -321,7 +321,9 @@ nb.define('select', {
      */
     disable: function() {
         if (this.isEnabled()) {
-            this.$node.addClass('is-disabled');
+            this.$node
+                    .addClass('is-disabled')
+                    .autocomplete('disable');
             this.trigger('nb-disabled', this);
         }
         return this;
@@ -334,7 +336,9 @@ nb.define('select', {
      */
     enable: function() {
         if (!this.isEnabled()) {
-            this.$node.removeClass('is-disabled');
+            this.$node
+                    .removeClass('is-disabled')
+                    .autocomplete('enable');
             this.trigger('nb-enabled', this);
         }
         return this;

--- a/unittests/spec/select/select.js
+++ b/unittests/spec/select/select.js
@@ -283,6 +283,14 @@ describe("Select Tests", function() {
     });
 
     describe("#disable()", function() {
+        beforeEach(function() {
+            sinon.spy($.fn, 'autocomplete');
+        });
+
+        afterEach(function() {
+            $.fn.autocomplete.restore();
+        });
+
         it("check state", function() {
             this.select.disable();
             expect(this.select.isEnabled()).to.not.ok();
@@ -299,11 +307,25 @@ describe("Select Tests", function() {
 
             expect(flag).to.not.ok();
         });
+
+        it("should call $.fn.autocomplete('disable')", function() {
+            this.select.disable();
+            expect($.fn.autocomplete.calledWithExactly('disable')).to.be.equal(true);
+        });
     });
 
     describe("#enable()", function() {
-        it("check state", function() {
+        beforeEach(function() {
+            sinon.spy($.fn, 'autocomplete');
+
             this.select.disable();
+        });
+
+        afterEach(function() {
+            $.fn.autocomplete.restore();
+        });
+
+        it("check state", function() {
             this.select.enable();
             expect(this.select.isEnabled()).to.ok();
         });
@@ -314,9 +336,13 @@ describe("Select Tests", function() {
                 flag = true;
             });
 
-            this.select.disable();
             this.select.enable();
             expect(flag).to.ok();
+        });
+
+        it("should call $.fn.autocomplete('enable')", function() {
+            this.select.enable();
+            expect($.fn.autocomplete.calledWithExactly('enable')).to.be.equal(true);
         });
     });
 


### PR DESCRIPTION
Иначе после выключения селекта на него всё еще можно нажать и открыть дропдаун.
