### PR TITLE
Размер опций селекта с темой `pseudo` должен соответствовать настройке селекта `size`

### DIFF
--- a/blocks/select/select.yate
+++ b/blocks/select/select.yate
@@ -58,14 +58,7 @@ match .select nb {
                     }
                 }
             </select>
-
-            // pseudo-buttons are smaller, so we should
-            size = if (.theme == 'pseudo') {
-              's'
-            } else {
-              .size
-            }
-            <div class="nb-select__dropdown nb-select__dropdown_size_{ size } nb-select_theme_{ .theme }"></div>
+            <div class="nb-select__dropdown nb-select__dropdown_size_{ .size } nb-select_theme_{ .theme }"></div>
       </span>
 }
 


### PR DESCRIPTION
Дизайнер просит тему псевдо, но с опциями побольше.

Убрал условие. Выглядит, вроде, неплохо.
Можно еще сделать отдельную настройку для размера опций.
