### PR TITLE
Fix double click bubbling for checkbox

### DIFF
--- a/blocks/checkbox/checkbox.js
+++ b/blocks/checkbox/checkbox.js
@@ -1,6 +1,14 @@
 nb.define('checkbox', {
     events: {
-        'click': '_onclick'
+        'change input': 'onchange'
+    },
+
+    onchange: function() {
+        if (this.$control.prop('checked')) {
+            this.check();
+        } else {
+            this.uncheck();
+        }
     },
 
     /**
@@ -108,19 +116,6 @@ nb.define('checkbox', {
             this.check();
         }
         return this;
-    },
-
-    _onclick: function(e) {
-        // <label><input/></label> may fires event twice
-        // @see http://www.w3.org/TR/html5/forms.html#labeled-control
-        if (e.target.nodeName === 'INPUT') {
-            // fires block events
-            if (this.$control.prop('checked')) {
-                this.check();
-            } else {
-                this.uncheck();
-            }
-        }
     },
 
     /**


### PR DESCRIPTION
'Cause of http://www.w3.org/TR/html5/forms.html#labeled-control checkbox' click bubbles twice. We used to have to check inside click's handler, but events bubbling anyway. It's not obvious when click fires twice on some element under the checkbox and can broke something.

When user clicks on checkbox (input itself or label) change event will be fired on input anyway and it will be once. So it's better to subscribe our handler on input change.
