### PR TITLE
jquery form serialize bug fix

### DIFF
--- a/blocks/checkbox/checkbox.yate
+++ b/blocks/checkbox/checkbox.yate
@@ -23,7 +23,7 @@ match .checkbox nb {
         }
 
 
-        <input class="nb-checkbox__input" id="nb-checkbox_{ uniq }">
+        <input class="nb-checkbox__input" id="nb-checkbox_{ uniq }" value="{ .value }">
             if .type == 'button' {
                 @type = 'checkbox'
             } else {
@@ -32,10 +32,6 @@ match .checkbox nb {
 
             if .name {
                 @name = .name
-            }
-
-            if .value {
-                @value = .value
             }
 
             if .tabindex {


### PR DESCRIPTION
интересный баг
есть 2 радиобатона одинакового имени
"вкл/выкл"
вкл - on
выкл - пустая строка

если value значение к true не приводится, то атрибут не добавляет
в результате $('form').serialize() игнорирует радиобатон без value атрибута и берет всегда значение "on", независимо от checked
