### PR TITLE
Show and Hide methods for blocks' prototype

### DIFF
--- a/blocks/common/common.js
+++ b/blocks/common/common.js
@@ -6,9 +6,20 @@ nb.define('base', {
     _oninit: function() {
         this.$node = $(this.node);
 
+        // mix all blocks with nb-common on init
+        this.$node.addClass('nb-common');
+
         if (this.oninit) {
             this.oninit();
         }
+    },
+
+    show: function() {
+        this.$node.removeClass('nb-common_hidden');
+    },
+
+    hide: function() {
+        this.$node.addClass('nb-common_hidden');
     },
 
     /**

--- a/blocks/common/common.styl
+++ b/blocks/common/common.styl
@@ -1,0 +1,13 @@
+// this could be overriden on project level
+// for custom show/hide effect
+//
+// For instance,
+//   .nb-common
+//     transition: opacity 0.2s ease
+//     opacity: 1
+//
+//   .nb-common_hidden
+//      opacity: 0
+//
+.nb-common_hidden
+    display: none

--- a/nanoislands.styl
+++ b/nanoislands.styl
@@ -27,4 +27,4 @@ set-skin-namespace('islands')
 @import "blocks/user/user.styl"
 @import "blocks/suggest/suggest.styl"
 @import "blocks/toggler/toggler.styl"
-@import "blocks/global.styl"
+@import "blocks/common/common.styl"

--- a/unittests/index.html
+++ b/unittests/index.html
@@ -39,6 +39,7 @@
 
     <script src="aftereach.js"></script>
 
+    <script src="spec/common/common.js"></script>
     <script src="spec/button/button.js"></script>
     <script src="spec/checkbox/checkbox.js"></script>
     <script src="spec/select/select.js"></script>

--- a/unittests/spec/common/common.js
+++ b/unittests/spec/common/common.js
@@ -1,0 +1,29 @@
+describe("Common Tests", function() {
+    beforeEach(function() {
+        var result = yr.run('main', {common: true});
+        $('.content').html(result);
+
+        nb.init();
+
+        this.button = nb.find('button');
+    });
+
+    afterEach(function() {
+        this.button.destroy();
+    });
+
+    describe("#hide()", function() {
+        it("should have nb-common_hidden class", function() {
+            this.button.hide();
+            expect(this.button.$node.hasClass('nb-common_hidden')).to.ok();
+        });
+    });
+
+    describe("#show()", function() {
+        it("should not have nb-common_hidden class", function() {
+            this.button.hide();
+            this.button.show();
+            expect(this.button.$node.hasClass('nb-common_hidden')).to.not.ok();
+        });
+    });
+});

--- a/unittests/spec/common/common.yate
+++ b/unittests/spec/common/common.yate
@@ -1,0 +1,6 @@
+match .common {
+    nb-button({
+        "content": "Button"
+        "id": "button"
+    })
+}

--- a/unittests/tests.yate
+++ b/unittests/tests.yate
@@ -1,4 +1,5 @@
 include '../nanoislands.yate'
+include 'spec/common/common.yate'
 include 'spec/button/button.yate'
 include 'spec/checkbox/checkbox.yate'
 include 'spec/input/input.yate'


### PR DESCRIPTION
It's useful to have API for show and hide blocks, similar to jQuery `show` and `hide`.

```
var button = nb.block(nodeButton);
button.hide();
```

instead of 

```
button.$node.hide();
```

Also `hide` could be tuned on each project (via css), it's `display: none` for default.

What do you think?
