### PR TITLE
Renamed is-hidden to have prefix, using kind

### DIFF
--- a/blocks/global.styl
+++ b/blocks/global.styl
@@ -14,9 +14,10 @@ for gap-side in 'top' 'left' 'bottom' 'right'
   .nb-gap_{gap-side}_l
     margin-{gap-side}: $islands_l
 
-// global hidden class
-.is-hidden
-  display: none !important
+// We need to deprecate `_hidden` somehow
+._hidden,
+.nb-is-hidden
+  kind: hidden
 
 // global class for links
 ._link

--- a/blocks/popup/popup.js
+++ b/blocks/popup/popup.js
@@ -348,7 +348,7 @@
             } else {
                 //  Попап закрыт. Будем открывать.
 
-                $(this.node).removeClass('is-hidden');
+                $(this.node).removeClass('nb-is-hidden');
                 //  Передвигаем попап.
                 this._move(where, how, params);
                 this.trigger('nb-opened');

--- a/blocks/popup/popup.yate
+++ b/blocks/popup/popup.yate
@@ -17,7 +17,7 @@ match .popupMenu nb {
     <div class="nb-popup _init">
         if !.static {
             @data-nb = "popup"
-            @class += " is-hidden"
+            @class += " nb-is-hidden"
         }
 
         apply . nb-main-attrs
@@ -53,7 +53,7 @@ func nb-popup(nodeset options) {
 }
 
 match .popup nb {
-    <div class="nb-popup _init is-hidden" data-nb='popup'>
+    <div class="nb-popup _init nb-is-hidden" data-nb='popup'>
 
         apply . nb-main-attrs
 
@@ -96,7 +96,7 @@ match .modalPopup nb {
     <div class="nb-popup _init nb-popup_type_modal">
         if !.static {
             @data-nb = "popup"
-            @class += " is-hidden"
+            @class += " nb-is-hidden"
         }
 
         if .theme {

--- a/libs/nanoblocks.js
+++ b/libs/nanoblocks.js
@@ -440,13 +440,13 @@ var nb = nb || {};
 
 //  Показываем блок.
     Block.prototype.show = function() {
-        $(this.node).removeClass('is-hidden');
+        $(this.node).removeClass('nb-is-hidden');
         this.trigger('show');
     };
 
 //  Прячем блок.
     Block.prototype.hide = function() {
-        $(this.node).addClass('is-hidden');
+        $(this.node).addClass('nb-is-hidden');
         this.trigger('hide');
     };
 


### PR DESCRIPTION
Oops, forgot to mention that our `is-`like modifiers should have `nb-` prefx too, so they won't have possible conflicts with any other projects.

Also, I think at least for the few releases we should have the old `_hidden` class to have hidden styles, so if someone've used it, they won't lose it. But we should encourage them to use the new proper class, as we would remove it in the future.

Also, using stylobate kind for hiding.
