### PR TITLE
Renamed is-disabled to have nb-prefix

### DIFF
--- a/blocks/button/button.js
+++ b/blocks/button/button.js
@@ -70,7 +70,7 @@ nb.define('button', {
     disable: function() {
         if (this.$node && this.$node.data('uiButton')) {
             this.$node.button('disable');
-            this.$node.addClass('is-disabled');
+            this.$node.addClass('nb-is-disabled');
             this.trigger('nb-disabled', this);
         }
         return this;
@@ -84,7 +84,7 @@ nb.define('button', {
     enable: function() {
         if (this.$node && this.$node.data('uiButton')) {
             this.$node.button('enable');
-            this.$node.removeClass('is-disabled');
+            this.$node.removeClass('nb-is-disabled');
             this.trigger('nb-enabled', this);
         }
         return this;

--- a/blocks/button/button.styl
+++ b/blocks/button/button.styl
@@ -5,7 +5,7 @@
 @import '_skin-dark'
 
 $skin-islands-button-content = '.nb-button__text'
-$skin-islands-button-disabled = '.is-disabled'
+$skin-islands-button-disabled = '.nb-is-disabled'
 
 // Обычная кнопка
 .nb-button_theme_normal

--- a/blocks/button/button.yate
+++ b/blocks/button/button.yate
@@ -22,7 +22,7 @@ match .button nb {
         apply . nb-main-attrs
 
         if .disabled {
-            @class += ' is-disabled'
+            @class += ' nb-is-disabled'
             @disabled = 'disabled'
         }
 

--- a/blocks/checkbox/checkbox.js
+++ b/blocks/checkbox/checkbox.js
@@ -187,7 +187,7 @@ nb.define('checkbox', {
      */
     enable: function() {
         if (!this.isEnabled()) {
-            this.$node.removeClass('is-disabled');
+            this.$node.removeClass('nb-is-disabled');
             this.$control.removeAttr('disabled');
             this.trigger('nb-enabled', this);
         }
@@ -202,7 +202,7 @@ nb.define('checkbox', {
     disable: function() {
         if (this.isEnabled()) {
             this.blur();
-            this.$node.addClass('is-disabled');
+            this.$node.addClass('nb-is-disabled');
             this.$control.attr('disabled', 'disabled');
             this.trigger('nb-disabled', this);
         }

--- a/blocks/checkbox/checkbox.yate
+++ b/blocks/checkbox/checkbox.yate
@@ -19,7 +19,7 @@ match .checkbox nb {
         apply . nb-main-attrs
 
         if .disabled  {
-             @class += ' is-disabled'
+             @class += ' nb-is-disabled'
         }
 
 

--- a/blocks/global.styl
+++ b/blocks/global.styl
@@ -33,6 +33,7 @@ a._link
 ._link_outer
   color: #070
 
-.is-disabled
-  skin: disabled
-  pointer-events: none
+// We need to deprecate is-disabled in favor of nb-is-disabled
+.is-disabled,
+.nb-is-disabled
+  kind: disabled 0.6

--- a/blocks/input/input.js
+++ b/blocks/input/input.js
@@ -190,7 +190,7 @@ nb.define('input', {
      * @returns {Object} nb.block
      */
     disable: function() {
-        this.$node.addClass('is-disabled');
+        this.$node.addClass('nb-is-disabled');
         this.$control.prop('disabled', true);
         this.trigger('nb-disabled', this);
         return this;
@@ -202,7 +202,7 @@ nb.define('input', {
      * @returns {Object} nb.block
      */
     enable: function() {
-        this.$node.removeClass('is-disabled');
+        this.$node.removeClass('nb-is-disabled');
         this.$control.prop('disabled', false);
         this.trigger('nb-enabled', this);
         return this;

--- a/blocks/input/input.styl
+++ b/blocks/input/input.styl
@@ -37,7 +37,7 @@
     kind: fill -1px
     skin: input-view no-focus
 
-  :not(.is-disabled):focus + .nb-input__view
+  :not(.nb-is-disabled):focus + .nb-input__view
     skin: input_focus
 
   .nb-input__reset

--- a/blocks/input/input.yate
+++ b/blocks/input/input.yate
@@ -37,7 +37,7 @@ match .input nb {
         }
 
         if .disabled {
-            @class += ' is-disabled'
+            @class += ' nb-is-disabled'
             @data-nb-disabled = 'true'
         }
 
@@ -123,7 +123,7 @@ match .textarea nb {
         }
 
         if .disabled {
-            @class += ' is-disabled'
+            @class += ' nb-is-disabled'
             @data-nb-disabled = 'true'
         }
 
@@ -198,7 +198,7 @@ match .inputSimple nb {
         }
 
         if .disabled {
-            @class += ' is-disabled'
+            @class += ' nb-is-disabled'
             @disabled = 'disabled'
             @data-nb-disabled = 'true'
         }
@@ -221,7 +221,7 @@ match .textareaSimple nb {
         }
 
         if .disabled {
-            @class += ' is-disabled'
+            @class += ' nb-is-disabled'
             @disabled = 'disabled'
             @data-nb-disabled = 'true'
         }

--- a/blocks/popup/popup.js
+++ b/blocks/popup/popup.js
@@ -507,7 +507,7 @@ nb.define('popup-toggler', {
         if (evt) {
             evt.preventDefault();
         }
-        if (!this.$node.hasClass('is-disabled') && this.popup) {
+        if (!this.$node.hasClass('nb-is-disabled') && this.popup) {
             this.popup.open(this.options);
             this.trigger('nb-opened', this);
         }
@@ -520,7 +520,7 @@ nb.define('popup-toggler', {
      * @returns {Object} nb.block
      */
     close: function() {
-        if (!this.$node.hasClass('is-disabled') && this.popup) {
+        if (!this.$node.hasClass('nb-is-disabled') && this.popup) {
             this.popup.close();
             this.trigger('nb-closed', this);
         }

--- a/blocks/radio-button/radio-button.yate
+++ b/blocks/radio-button/radio-button.yate
@@ -40,7 +40,7 @@ match .radio-button nb {
                     }
 
                     if .disabled {
-                        @class += ' is-disabled js-disabled'
+                        @class += ' nb-is-disabled js-disabled'
                         @disabled = 'disabled'
                     }
 

--- a/blocks/select/select.js
+++ b/blocks/select/select.js
@@ -371,7 +371,7 @@ nb.define('select', {
     disable: function() {
         if (this.isEnabled()) {
             this.$node
-                .addClass('is-disabled')
+                .addClass('nb-is-disabled')
                 .autocomplete('disable');
             this.trigger('nb-disabled', this);
         }
@@ -386,7 +386,7 @@ nb.define('select', {
     enable: function() {
         if (!this.isEnabled()) {
             this.$node
-                .removeClass('is-disabled')
+                .removeClass('nb-is-disabled')
                 .autocomplete('enable');
             this.trigger('nb-enabled', this);
         }
@@ -398,7 +398,7 @@ nb.define('select', {
      * @returns {Boolean}
      */
     isEnabled: function() {
-        return !this.$node.hasClass('is-disabled');
+        return !this.$node.hasClass('nb-is-disabled');
     },
 
     /*

--- a/blocks/select/select.styl
+++ b/blocks/select/select.styl
@@ -83,5 +83,6 @@
 .nb-select_theme_normal .ui-menu-item:hover > .nb-select__a > .nb-select__text
   skin: menu-item_hover
 
+// FIXME: we need to use `nb-is-disabled` here
 .nb-select_theme_normal .ui-menu-item_disabled_yes
-  skin: disabled
+  kind: disabled 0.6 (-nested '')

--- a/blocks/select/select.yate
+++ b/blocks/select/select.yate
@@ -17,7 +17,7 @@ match .select nb {
         }
 
         if .disabled  {
-            @class += ' is-disabled'
+            @class += ' nb-is-disabled'
             @disabled = 'disabled'
         }
 

--- a/blocks/slider/slider.js
+++ b/blocks/slider/slider.js
@@ -21,7 +21,7 @@ nb.define('slider', {
 
         this.$body.slider({
             range: 'min',
-            disabled: this.$node.hasClass('is-disabled'),
+            disabled: this.$node.hasClass('nb-is-disabled'),
             value: parseFloat(this.data.value),
             change: function(e, ui) {
                 this.$control.val(ui.value);
@@ -93,7 +93,7 @@ nb.define('slider', {
      * @return {Object} nb.block
      */
     disable: function() {
-        this.$node.addClass('is-disabled');
+        this.$node.addClass('nb-is-disabled');
         this.$body.slider('disable');
         this.trigger('nb-disabled', this);
         return this;
@@ -105,7 +105,7 @@ nb.define('slider', {
      * @return {Object} nb.block
      */
     enable: function() {
-        this.$node.removeClass('is-disabled');
+        this.$node.removeClass('nb-is-disabled');
         this.$body.slider('enable');
         this.trigger('nb-enabled', this);
         return this;

--- a/blocks/slider/slider.styl
+++ b/blocks/slider/slider.styl
@@ -9,7 +9,7 @@ nb-slider()
 
     position: relative
 
-  .nb-slider.is-disabled .ui-slider-handle
+  .nb-slider.nb-is-disabled .ui-slider-handle
     cursor: default
 
 

--- a/blocks/slider/slider.yate
+++ b/blocks/slider/slider.yate
@@ -20,7 +20,7 @@ match .slider nb {
         }
 
         if .disabled {
-            @class += ' is-disabled'
+            @class += ' nb-is-disabled'
         }
 
         <div class='nb-slider__body nb-slider__body_type_{ .type }'>

--- a/blocks/suggest/suggest.js
+++ b/blocks/suggest/suggest.js
@@ -285,7 +285,7 @@
         disable: function() {
             if (this.isEnabled()) {
                 this.input.disable();
-                this.$node.addClass('is-disabled');
+                this.$node.addClass('nb-is-disabled');
                 this.$jUI.suggest('disable');
                 this.trigger('nb-disabled', this);
             }
@@ -300,7 +300,7 @@
         enable: function() {
             if (!this.isEnabled()) {
                 this.input.enable();
-                this.$node.removeClass('is-disabled');
+                this.$node.removeClass('nb-is-disabled');
                 this.$jUI.suggest('enable');
                 this.trigger('nb-enabled', this);
             }
@@ -312,7 +312,7 @@
          * @returns {Boolean}
          */
         isEnabled: function() {
-            return !this.$node.hasClass('is-disabled');
+            return !this.$node.hasClass('nb-is-disabled');
         },
 
         /**

--- a/blocks/suggest/suggest.yate
+++ b/blocks/suggest/suggest.yate
@@ -22,7 +22,7 @@ match .suggest nb {
         apply . nb-main-attrs
 
         if .disabled  {
-          @class += ' is-disabled'
+          @class += ' nb-is-disabled'
         }
 
         nb-input({

--- a/blocks/toggler/toggler.js
+++ b/blocks/toggler/toggler.js
@@ -77,7 +77,7 @@ nb.define('toggler', {
      */
     disable: function() {
         this.$control.prop('disabled', true);
-        this.$node.addClass('is-disabled');
+        this.$node.addClass('nb-is-disabled');
         this.trigger('nb-disabled', this);
         return this;
     },
@@ -88,7 +88,7 @@ nb.define('toggler', {
      */
     enable: function() {
         this.$control.prop('disabled', false);
-        this.$node.removeClass('is-disabled');
+        this.$node.removeClass('nb-is-disabled');
         this.trigger('nb-enabled', this);
         return this;
     },

--- a/blocks/toggler/toggler.styl
+++ b/blocks/toggler/toggler.styl
@@ -12,7 +12,7 @@ $toggler-width_m = 82px
   overflow: hidden
   outline: none
 
-.nb-toggler:focus:not(.is-disabled)
+.nb-toggler:focus:not(.nb-is-disabled)
 .nb-toggler.is-focused
   box-shadow: 0 1px 0 rgba(0,0,0,.07), 0 0 6px 2px rgba(255,204,0,.7)
 

--- a/blocks/toggler/toggler.yate
+++ b/blocks/toggler/toggler.yate
@@ -17,7 +17,7 @@ match .toggler nb {
             @class += ' is-checked'
         }
         if .disabled {
-            @class += ' is-disabled'
+            @class += ' nb-is-disabled'
         }
         <label class="nb-toggler__label">
             <input type="checkbox" class="nb-toggler__checkbox" >

--- a/blocks/tooltip/tooltip.js
+++ b/blocks/tooltip/tooltip.js
@@ -8,7 +8,7 @@ nb.define('tooltip-jq-toggler', {
     },
 
     'onmouseenter': function() {
-        if (this.$node.hasClass('is-disabled')) {
+        if (this.$node.hasClass('nb-is-disabled')) {
             return true;
         }
 

--- a/unittests/spec/slider/slider.js
+++ b/unittests/spec/slider/slider.js
@@ -133,7 +133,7 @@ describe('Slider Tests', function() {
         it('should has disabled mod', function() {
             this.slider.disable();
 
-            expect(this.slider.$node.hasClass('is-disabled')).to.be.ok();
+            expect(this.slider.$node.hasClass('nb-is-disabled')).to.be.ok();
         });
     });
 


### PR DESCRIPTION
The same thing as with #223 — the `is-` classes should have prefixes, so there wouldn't be any overlap with other projects.

The old `is-disabled` class is as well deprecated, so we would remove it in the future versions.

Also using stylobate kind for disabling things (it have `pointer-events: none` from the box etc.)
