### PR TITLE
Fixed resize of complex textarea

### DIFF
--- a/blocks/input/input.styl
+++ b/blocks/input/input.styl
@@ -28,7 +28,7 @@
     width: 100%
     height: 100%
 
-  textarea&
+  & textarea.nb-input__controller
     vertical-align: top
     resize: none
 

--- a/demo/checkbox.yate
+++ b/demo/checkbox.yate
@@ -97,13 +97,6 @@ func checkbox() {
     </div>
     <div class="demo-section">
         <div class="demo-h3">
-            'Type: Button'
-        </div>
-
-        show(checkbox-button())
-    </div>
-    <div class="demo-section">
-        <div class="demo-h3">
             'Size: S '
             <span class="demo-code demo-code_small">
                 '.nb-checkbox_size_s'


### PR DESCRIPTION
Complex textarea shouldn't have resize control, fixed the selector for this. Also, deleted duplicated button-checkboxes from demo.
