### PR TITLE
Fix focus/blur for complex input

### DIFF
--- a/blocks/common/common.js
+++ b/blocks/common/common.js
@@ -12,6 +12,7 @@ nb.define('base', {
      */
     _oninit: function() {
         this.$node = $(this.node);
+        this.$document = $(document);
 
         if (this.oninit) {
             this.oninit();

--- a/blocks/input/input.js
+++ b/blocks/input/input.js
@@ -5,9 +5,7 @@
 nb.define('input', {
     events: {
         'click': 'focus',
-        'mousedown .nb-input__reset': 'reset',
-        'focusin': 'focus',
-        'focusout': 'blur'
+        'mousedown .nb-input__reset': 'reset'
     },
 
     /**
@@ -53,6 +51,16 @@ nb.define('input', {
         nb.on('is-focusedout', function() {
             that.blur();
         });
+
+        this._onmousedown = function(e) {
+            if ($.contains(this.$control.get(0), e.target)) {
+                return;
+            }
+            this.blur();
+        }.bind(this);
+
+        this.$document.on('mousedown', this._onmousedown);
+        this.$document.on('touchstart', this._onmousedown);
 
         this.trigger('nb-inited', this);
     },
@@ -207,6 +215,7 @@ nb.define('input', {
         }
 
         this.focused = false;
+        this.$control.get(0).blur();
         this.trigger('nb-blured', this);
 
         return this;
@@ -359,6 +368,8 @@ nb.define('input', {
             this.error.nbdestroy();
             this.error.$node.remove();
         }
+        this.$document.off('mousedown', this._onmousedown);
+        this.$document.off('touchstart', this._onmousedown);
         this.nbdestroy();
     }
 }, 'base');

--- a/blocks/input/input.styl
+++ b/blocks/input/input.styl
@@ -40,8 +40,8 @@
     kind: fill -1px
     skin: input-view no-focus
 
-  :not(.nb-is-disabled):focus + .nb-input__view
-  :not(.nb-is-disabled).nb-is-focused + .nb-input__view
+  &:not(.nb-is-disabled):focus .nb-input__view
+  &:not(.nb-is-disabled).nb-is-focused .nb-input__view
     skin: input_focus
 
   .nb-input__reset


### PR DESCRIPTION
- there were no visual representation of focus for complex input, fix styl a little bit;
- remove focusin/focusout events for block, 'cause on native `$control` blur `focusout` fires on block (wrapper for `$control` in case of a complex input, so it bubbles to block) and gets infinity recursion;
- fire blur on native control on block's blur.
