### PR TITLE
Autoclose option for the modal popup

### DIFF
--- a/blocks/popup/popup.js
+++ b/blocks/popup/popup.js
@@ -456,7 +456,7 @@
                     position: {
                         using: using
                     },
-                    autoclose: typeof how.autoclose !== 'undefined' ? how.autoclose : true
+                    autoclose: typeof how.autoclose !== 'undefined' ? how.autoclose : false
                 });
 
                 return;


### PR DESCRIPTION
Fixes #287 by checking if 'autoclose' option is set outside the mousedown/touchstart callback and not checking for the 'modal' option
