### PR TITLE
Исправить вычисление направления хвостика

### DIFF
--- a/blocks/popup/popup.styl
+++ b/blocks/popup/popup.styl
@@ -65,22 +65,6 @@
 .nb-popup-outer.ui-dialog .ui-dialog-content
   padding:  0
 
-.nb-popup_to_bottom .nb-popup__tail_to_right
-.nb-popup_to_top .nb-popup__tail_to_right
-  left: 75%
-
-.nb-popup_to_bottom .nb-popup__tail_to_left
-.nb-popup_to_top .nb-popup__tail_to_left
-  left: 25%
-
-.nb-popup_to_left .nb-popup__tail_to_bottom
-.nb-popup_to_right .nb-popup__tail_to_bottom
-  top: 75%
-
-.nb-popup_to_left .nb-popup__tail_to_top
-.nb-popup_to_right .nb-popup__tail_to_top
-   top: 25%
-
 .nb-popup-outer
  .nb-popup
    position: static


### PR DESCRIPTION
Текущее вычисление основано на ошибочном предположении, что поле `ui.important` дает намек на то, куда надо направлять хвостик. Оказывается, это не так, поправил на такой алгоритм:

> Сперва для каждого элемента вычисляются координаты вершин опоясывающего
> прямоугольника. После этого, для каждой внешней полуплоскости,
> образованной сторонами прямоугольника целевого элемента (т.н. тогглера)
> проверяется попадание вершин прямоугольника попапа.
