### PR TITLE
Удалил класс is-checked у баттона

### DIFF
--- a/blocks/button/button.yate
+++ b/blocks/button/button.yate
@@ -42,10 +42,6 @@ func _nb-button-attributes(type) {
         @class += ' _nb-attach-button'
     }
 
-    if .checked {
-        @class += ' is-checked'
-    }
-
     if type == 'button' {
         if .name {
             @name = .name


### PR DESCRIPTION
It seems that button styles for "checkbox type=button" inherits from selector with ": checked", adding special class is redundant.
