### PR TITLE
Некорректное отображение саджеста с пользователями

### DIFF
--- a/blocks/user/user.styl
+++ b/blocks/user/user.styl
@@ -14,6 +14,13 @@ nb-user()
     display: inline-block
     position: relative
 
+    &:after
+      content: ""
+      display: table
+      width: 100%
+      height: 0
+      visibility: hidden
+
   ._nb-user-pseudo
     display: inline-block
     width: 100%
@@ -59,7 +66,6 @@ nb-user()
 
   ._nb-normal-user
     font-size: $fzm
-    height: $m
 
     .nb-user-avatar
       width: $m
@@ -67,7 +73,6 @@ nb-user()
 
   ._nb-small-user
     font-size: $fzs
-    height: $s
 
     .nb-user-avatar
       width: $s
@@ -124,13 +129,9 @@ nb-user()
       white-space: nowrap
       position: relative
 
-    .nb-user-avatar
-      position: absolute
-      top: 0
-
   ._nb-user_justify._nb-user_rtl
-      .nb-user-avatar
-        right: 0
+    .nb-user-avatar
+      float: right
 
   ._nb-user_justify._nb-user_rtl._nb-small-user
     ._nb-user-label
@@ -142,7 +143,7 @@ nb-user()
 
   ._nb-user_justify._nb-user_ltr
     .nb-user-avatar
-      left: 0
+      float: left
 
   ._nb-user_justify._nb-user_ltr._nb-small-user
     ._nb-user-label

--- a/blocks/user/user.yate
+++ b/blocks/user/user.yate
@@ -24,13 +24,12 @@ match .user nb {
 
         if !.rightToLeft {
             @class += ' _nb-user_ltr'
-            apply . nb-user-pic
-            apply . nb-user-name
         } else {
             @class += ' _nb-user_rtl'
-            apply . nb-user-name
-            apply . nb-user-pic
         }
+
+        apply . nb-user-pic
+        apply . nb-user-name
     </span>
 }
 


### PR DESCRIPTION
При изменении высоты строки, т.к. высота блока фиксирована, можем получить небольшой внутренний скролл:

![](https://yadi.sk/d/xQkBWI9ET63Un_XXL.jpg)
![](https://yadi.sk/d/imv-1M-HT62ts_XXL.jpg)

Предлагаю не фиксировать высоту, она будет определена правильно вложенными элементами.

![](https://yadi.sk/d/oqpeTRPKT635R_XXL.jpg)

Чтобы высота правильно определялась пришлось убрать абсолютно позиционированную аватарку и сделать ее плавающей.
