### PR TITLE
Update to latest es5-shim because of warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git://github.com/yandex-ui/nanoislands.git"
   },
   "dependencies": {
-    "es5-shim": "3.0.2",
+    "es5-shim": "3.4.0",
     "stylobate": "0.24.x",
     "stylobate-islands": "0.27.x"
   },


### PR DESCRIPTION
`npm WARN deprecated es5-shim@3.0.2: Please upgrade; 3.1.0 fixes String#replace in latest Firefox`
