### PR TITLE
Better placement of the complex input’s view

### DIFF
--- a/blocks/input/input.styl
+++ b/blocks/input/input.styl
@@ -40,7 +40,9 @@
 
   ._nb-input-controller
     kind: input
+
     z-index: 9
+
     width: 100%
     height: 100%
 
@@ -52,6 +54,8 @@
     border: 1px solid transparent
     kind: fill -1px
     skin: input-view no-focus
+
+    z-index: 8
 
   &:not(._nb-is-disabled):focus ._nb-input-view
   &:not(._nb-is-disabled)._nb-is-focused ._nb-input-view


### PR DESCRIPTION
Complex inputs in groups should have its view to overlap the nearest buttons and other stuff. This fixes it.
