### PR TITLE
Исправление отступов у ссылок в `popupMenu`

### DIFF
--- a/blocks/popup/popup.styl
+++ b/blocks/popup/popup.styl
@@ -17,12 +17,6 @@
     skin: menu-item (_hover '&:hover, &:focus')
     outline: none
 
-    &:first-child
-      margin-top: ($islands_s / 2)
-
-    &:last-child
-      margin-bottom: ($islands_s / 2)
-
   & ._nb-popup-separator
     skin: menu-separator padded
 
@@ -32,6 +26,13 @@
     padding: 0
     list-style: none
     outline: none
+
+  & ._nb-popup-line
+    &:first-child
+      margin-top: ($islands_s / 2)
+    &:last-child
+      margin-bottom: ($islands_s / 2)
+
 ._nb-modal-popup
   ._nb-popup-title
     font: $font-h3


### PR DESCRIPTION
Раньше вертикальные отступы проставлялись каждой ссылке, теперь только первой и последней.
