### PR TITLE
Модальный попап закрывается при клике на скроллбар

### DIFF
--- a/blocks/popup/popup.js
+++ b/blocks/popup/popup.js
@@ -31,23 +31,32 @@
             var that = this;
 
             if (that.options.autoclose) {
-                this._onmousedown = function(e) {
-                    that.options.closedByOuterClick = true;
-                    // e.which === 3 -> right mouse button
-                    // e.which === 2 -> middle (wheel) mouse button
-                    if (e.which === 2 || e.which === 3) {
-                        return;
-                    }
+                if (this.options.modal) {
+                    this._onmousedown = function(e) {
+                        that.options.closedByOuterClick = true;
+                        if (e.which === 2 || e.which === 3) {
+                            return;
+                        }
+                        that.close();
+                    };
+                    this.overlay.click(this._onmousedown);
+                } else {
+                    this._onmousedown = function(e) {
+                        that.options.closedByOuterClick = true;
+                        if (e.which === 2 || e.which === 3) {
+                            return;
+                        }
 
-                    if ($.contains(that.uiDialog[0], e.target)) {
-                        return;
-                    }
+                        if ($.contains(that.uiDialog[0], e.target)) {
+                            return;
+                        }
 
-                    that.close();
-                };
+                        that.close();
+                    };
 
-                this.document.on('mousedown', this._onmousedown);
-                this.document.on('touchstart', this._onmousedown);
+                    this.document.on('mousedown', this._onmousedown);
+                    this.document.on('touchstart', this._onmousedown);
+                }
             }
 
             this._onresize = $.throttle(this._position.bind(this), TIME_PER_FRAME, false, false);
@@ -65,6 +74,7 @@
             if (this.options.autoclose) {
                 this.document.off('mousedown', this._onmousedown);
                 this.document.off('touchstart', this._onmousedown);
+                this.document.off('click', this._onmousedown);
             }
 
             if (this._onresize) {
@@ -78,6 +88,7 @@
                 this._super();
             }
         },
+        _keepFocus: $.noop,
         _create: function() {
             this.options.dialogClass += _getUIDialogExtraClass.call(this);
             this.options.dialogClass += (this.options.position.fixed) ? ' ui-dialog-fixed' : '';

--- a/unittests/spec/popup/popup.js
+++ b/unittests/spec/popup/popup.js
@@ -7,12 +7,14 @@ describe("Popup Tests", function() {
         nb.init();
 
         this.popup = nb.find('popup');
+        this.popupModal = nb.find('popup-modal');
         this.toggler = nb.find('popup-toggler');
     });
 
     afterEach(function() {
         this.popup.destroy();
         this.toggler.destroy();
+        this.popupModal.destroy();
     });
 
     describe("YATE API", function() {
@@ -28,6 +30,11 @@ describe("Popup Tests", function() {
             expect(nb.find('popup-w-t').$node.parent().find('._nb-popup-tail').length).to.equal(0);
         });
 
+        it('Popup`s tail should not be placed on the edge of popup', function() {
+            var toggler = nb.find('popup-toggler-tight');
+            toggler.open();
+            expect(nb.find('popup-tight').$node.parent().find('._nb-popup-tail')[0].style.left).to.equal('13px');
+        });
     });
     describe("Init", function() {
         it("Init popup", function() {
@@ -166,6 +173,28 @@ describe("Popup Tests", function() {
             expect(flag).to.ok();
         });
 
+        it("#Close check event", function() {
+            var flag = false;
+            this.popup.on('nb-closed', function() {
+                flag = true;
+            });
+
+            this.popup.open({where: this.toggler.node, appendTo: '.content'});
+            this.popup.close();
+            expect(flag).to.ok();
+        });
+
+        it('#Click on overlay should close popup', function(done) {
+            this.popupModal.on('nb-closed', function() {
+                done();
+            });
+
+            this.popupModal.open();
+
+            var $overlay = $('.ui-widget-overlay');
+            $overlay.click();
+        });
+
         it("#getContent() ", function() {
             expect(this.popup.getContent()).to.equal('Удалить');
         });
@@ -197,28 +226,6 @@ describe("Popup Tests", function() {
         it("should destroy nb.block", function() {
             this.popup.destroy();
             expect(nb.hasBlock($('#popup')[0])).to.be.equal(false);
-        });
-    });
-
-
-    describe("#Popup", function() {
-        it("#Close check event", function() {
-            var flag = false;
-            this.popup.on('nb-closed', function() {
-                flag = true;
-            });
-
-            this.popup.open({where: this.toggler.node, appendTo: '.content'});
-            this.popup.close();
-            expect(flag).to.ok();
-        });
-    });
-
-    describe("Tail positioning", function() {
-        it('should not be placed on the edge of popup', function() {
-            var toggler = nb.find('popup-toggler-tight');
-            toggler.open();
-            expect(nb.find('popup-tight').$node.parent().find('._nb-popup-tail')[0].style.left).to.equal('13px');
         });
     });
 });

--- a/unittests/spec/popup/popup.yate
+++ b/unittests/spec/popup/popup.yate
@@ -46,4 +46,12 @@ match .popup {
     'withoutTail': true()
     'content': 'Удалить'
  })
+
+ nb-popup({
+    'id': 'popup-modal'
+    'data-nb': {
+        'modal': true()
+    }
+    'content': 'Hello, words!'
+})
 }


### PR DESCRIPTION
Слушаю закрытие модального попапа не на `mousedown` на документе, а на клик оверлея. В таком случае, когда кликаешь на скроллбар, то обработчик не вызывается (скроллбар перекрывает оверлей в любой случае).

Кроме того, есть `_keepFocus` базового диалога, это обработчик для `mousedown` оверлея, внутри которого есть `preventDefault`. Дефолтное поведение в данном случае — дать возможность просскроллить, удерживая нажатой левую клавишу.

Переопределил [`_keepFocus`](https://github.com/jquery/jquery-ui/commit/2a2a2c017c4395799ec07666f4ca14e078b52b5b).
