### PR TITLE
Синхронизировать фон для автозаполненного сложного поля для ввода

### DIFF
--- a/blocks/input/input.styl
+++ b/blocks/input/input.styl
@@ -102,5 +102,12 @@
 ._nb-input::-ms-clear
   display: none
 
+// Overriding Webkit's default background color for autofilled inputs
+// to ensure consistent appearance across platforms.
+._nb-input-controller:-webkit-autofill
+  // NOTE: Cannot use `background` because native Webkit styles `!important`-ize
+  // default background color.
+  box-shadow: inset 0 0 0 900px $backgroundAutofill
 
-
+._nb-input-controller:-webkit-autofill + ._nb-input-view
+  background: $backgroundAutofill

--- a/blocks/vars/colors.styl
+++ b/blocks/vars/colors.styl
@@ -31,5 +31,8 @@ $patch               = #FF6665
 
 $backgroundHover = rgba-ie($backgroundSelected, 0.45, $background)
 
+// Background of autofilled inputs.
+$backgroundAutofill = #FAFFBD
+
 // цвет обычной ссылки
-$link                = #22c
+$link                = #22C


### PR DESCRIPTION
При автозаполнении сложных полей для ввода можно наблюдать такое:

![Autocompleted input](http://i.imgur.com/bqzpGEW.png)

Попробовал синхронизировать фоны через JS, на мой взгляд получилось громоздко, но вдруг у других сервисов есть потребность в исправлении, которая все нивелирует.
