### PR TITLE
Update es5-shim to v4.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "yate": "0.0.71",
-    "es5-shim": "3.4.0",
+    "es5-shim": "4.0.3",
     "stylobate": "0.24.x",
     "stylobate-islands": "0.27.x"
   },


### PR DESCRIPTION
1. v3.4 is deprecated.

```
npm WARN deprecated es5-shim@3.4.0: v4.0.0 no longer shims Array#splice with ES5 behavior, makes shims non-enumerable when possible, and fixes a bug in ES3 browsers referencing String#indexOf/lastIndexOf before polyfilling it
```
1. v4 fixes Array.prototype.splice with negative index

``` js
[1,2,3].splice(-1)
 // -> [], but should be [3]
```
