### PR TITLE
ошибка при выборе элемента саджеста

### DIFF
--- a/blocks/suggest/suggest.js
+++ b/blocks/suggest/suggest.js
@@ -231,7 +231,9 @@
 
             this.$jUI.on('suggestselect.nb-suggest', function(e, item) {
                 this.$selected = item.item;
-                this.input.setValue(item.item.value);
+                if (this.input) {
+                    this.input.setValue(item.item.value);
+                }
                 this.trigger('nb-select', this, item.item);
             }.bind(this));
 


### PR DESCRIPTION
В этом коммите
https://github.com/yandex-ui/nanoislands/commit/e795b8a6fec22c19f12b747c741282faf66e6c40

выполняется попытка установки значения в свойство input, которое может быть не определено.
В результате ошибка.
Везде по коду выполняется проверка наличия этого свойства перед обращением.

Не уверен, но возможно надо при отсутствии `this.input` делать установку значения в `this.$control`.
```js
if (this.input) {
    this.input.setValue(item.item.value);
} else {
    this.$control.val(item.item.value);
}
```
Не уверен, потому что при отсутствии `this.input`, значение в `this.$control` и так подставляет.

Либо вообще эту проверку и установку значения вынести в метод `setValue` и вызывать здесь его.