### PR TITLE
popup#setContent fixes for nb-popup-menu

### DIFF
--- a/blocks/popup/popup.js
+++ b/blocks/popup/popup.js
@@ -490,16 +490,25 @@
 
         // ----------------------------------------------------------------------------------------------------------------- //
         oninit: function() {
-            var that = this;
             var data = this.nbdata();
 
             if ('modal' in data) {
                 this.modal = true;
             }
 
-            this.$menu = this.$node.find('._nb-popup-menu');
+            this._initPopupMenu();
+        },
+
+        /**
+         * Initialize popup menu
+         * @private
+         */
+        _initPopupMenu: function() {
+            // we need first element only because there can be multilevel menu
+            this.$menu = this.$node.find('._nb-popup-menu').eq(0);
 
             if (this.$menu.length) {
+                var that = this;
                 this.$menu.menu({
                     select: function(event, ui) {
                         that.trigger('nb-select', {
@@ -606,12 +615,27 @@
         },
 
         /**
-         * Set content of popup (not menu, not modal)
+         * Set content of popup (not modal)
+         * @description
+         * For popup-menu `content` is new `<ul class="_nb-popup-menu">...</ul>`.
+         * Use yate mode `nb-popup-menu-content` to generate it.
+         * @param {string} content New popup/menu content
          * @fires 'nb-content-set'
          * @returns {Object} nb.block
          */
         setContent: function(content) {
-            this.$node.find('._nb-popup-content').html(content);
+            if (this.$menu.length) {
+                // destroy old menu
+                this.$menu.menu('destroy');
+                // replace with new one
+                this.$menu.replaceWith(content);
+                // init
+                this._initPopupMenu();
+
+            } else {
+                this.$node.find('._nb-popup-content').html(content);
+            }
+
             this.trigger('nb-content-set');
             return this;
         },

--- a/blocks/popup/popup.yate
+++ b/blocks/popup/popup.yate
@@ -19,25 +19,32 @@ match .popupMenu nb {
             @data-nb-withoutTail = 'true'
         }
 
-        <ul class="_nb-popup-menu">
-            for .menu {
-                if .separator {
-                    <li class="_nb-popup-separator"></li>
-                } else {
-                   <li class="_nb-popup-line">
-                        <a class="_nb-popup-link">
-                            if .href {
-                                @href = .href
-                            }
-
-                            apply . nb-main-attrs
-                            html(.content)
-                        </a>
-                    </li>
-                }
-            }
-        </ul>
+        apply . nb-popup-menu-content
     </div>
+}
+
+// you can use this mode to change popup-menu's content dynamicly
+match .popupMenu nb-popup-menu-content {
+    <ul class="_nb-popup-menu">
+        apply .menu nb-popup-menu-content-item
+    </ul>
+}
+
+match .menu nb-popup-menu-content-item {
+    if .separator {
+        <li class="_nb-popup-separator"></li>
+    } else {
+        <li class="_nb-popup-line">
+            <a class="_nb-popup-link">
+                if .href {
+                    @href = .href
+                }
+
+                apply . nb-main-attrs
+                html(.content)
+            </a>
+        </li>
+    }
 }
 
 


### PR DESCRIPTION
Правки, чтобы правильно работал `#setContent` у `nb-popup-menu`.
Также сделана мода `nb-popup-menu-content`, чтобы удобно генерировать ноду для `#setContent`

Еще теперь проект может легко реализовать многоуровневые меню, сделав такое переопределение
```
match .menu nb-popup-menu-content-item {
    if .separator {
        <li class="_nb-popup-separator"></li>
    } else {
        <li class="_nb-popup-line">
            <a class="_nb-popup-link">
                if .href {
                    @href = .href
                }

                apply . nb-main-attrs
                html(.content)
            </a>
            // Правка для многоуровненого меню
            if (.menu) {
                <ul class="_nb-popup _nb-popup-menu">
                    apply .menu nb-popup-menu-content-item
                </ul>
            }
        </li>
    }
}
```