### PR TITLE
Включить контейнерную сборку на TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: false
 node_js:
   - 0.10
 


### PR DESCRIPTION
Травис советует (умоляет) перейти на [контейнерное тестирование](http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade).

Из плюсов - тестирование разворачивается быстрее
Из минусов - нельзя использовать `sudo`

Другая возможность для оптимизации - [Caching the dependencies](http://docs.travis-ci.com/user/speeding-up-the-build/#Caching-the-dependencies) для некоторых модулей (PhantomJS).
Но это уж как-нибудь в другой раз