### PR TITLE
Не склеивать класс, указанный при вызове `nb-island`, с классом в шаблоне

### DIFF
--- a/blocks/island/island.yate
+++ b/blocks/island/island.yate
@@ -25,7 +25,7 @@ match .island nb {
             ''
         })
 
-        @class += 'nb-island _nb{ padding }{ type }-island'
+        @class += ' nb-island _nb{ padding }{ type }-island'
 
         if .content {
             html(.content)


### PR DESCRIPTION
Сейчас, при указании класса при вызове блока:

```
nb-island({
  'class': 'my-block'
})
```

получим класс `my-blocknb-island`.