### PR TITLE
[Bug] #496 Не затирать модификатор обертки попапа после второго открытия

### DIFF
--- a/blocks/popup/popup.js
+++ b/blocks/popup/popup.js
@@ -1,6 +1,6 @@
-/*! 
+/*!
  * ### jQuery UI Depends
- * 
+ *
  * - jquery.ui.dialog.js
  * - jquery.ui.core.js
  * - jquery.ui.widget.js
@@ -110,8 +110,6 @@
         },
         _keepFocus: $.noop,
         _create: function() {
-            this.options.dialogClass += _getUIDialogExtraClass.call(this);
-            this.options.dialogClass += (this.options.position.fixed) ? ' ui-dialog-fixed' : '';
             this._super();
             this.element[0].widget = this;
         },
@@ -454,12 +452,12 @@
      *  функция вернет строку 'nb-popup-outer_mod nb-popup-outer_another-mod'
      *
      */
-    function _getUIDialogExtraClass() {
-        var popupClasses = this.element.attr('class').split(' ') || [];
+    function _getUIDialogExtraClass(classes) {
+        var popupClasses = classes.split(' ') || [];
         // не матчимся на _ в начале слова
         // иначе это глобальный класс,
         // не мачимся на __, чтобы ислючить элемент
-        var modRe = /\w+\_(?!_)/;
+        var modRe = /[^_]_(?!_)/;
         var uiDialogClasses;
 
         uiDialogClasses = $.map(popupClasses, function(item) {
@@ -739,6 +737,10 @@
 
             //  Модальный попап двигать не нужно.
             if (this.modal) {
+                var dialogClass = params['class'] || '_nb-popup-outer ui-dialog-fixed ';
+
+                dialogClass += _getUIDialogExtraClass(this.$node.attr('class'));
+
                 $(this.node).baseDialog({
                     height: params.height || data.height,
                     minHeight: params.minHeight || data.minheight,
@@ -749,7 +751,7 @@
                     modal: true,
                     resizable: false,
                     draggable: false,
-                    dialogClass: params['class'] || '_nb-popup-outer ui-dialog-fixed',
+                    dialogClass: dialogClass,
                     close: function() {
                         that.close();
                     },
@@ -765,12 +767,22 @@
             }
 
             if (!this.animationInProgress) {
+                var dialogClass = '_nb-popup-outer ui-dialog-no-close ';
+
+                if (params['class']) {
+                    dialogClass += params['class'];
+                }
+                if (isFixed) {
+                    dialogClass += ' ui-dialog-fixed';
+                }
+                dialogClass += _getUIDialogExtraClass(this.$node.attr('class'));
+
                 this.$node.hide().contextDialog({
                     height: params.height || data.height || 'auto',
                     minHeight: params.minHeight || data.minheight || 'auto',
                     maxHeight: params.maxHeight || data.maxheight || 'auto',
                     width: params.width || data.width || 'auto',
-                    dialogClass: params['class'] ? '_nb-popup-outer ui-dialog-no-close ' + params['class'] : '_nb-popup-outer ui-dialog-no-close',
+                    dialogClass: dialogClass,
                     position: {
                         // где попап
                         at: (how.at ? how.at : 'center bottom'),// + ' center',

--- a/unittests/spec/popup/popup.js
+++ b/unittests/spec/popup/popup.js
@@ -45,6 +45,102 @@ describe("Popup Tests", function() {
         });
     });
 
+    describe("Popup extra modifier", function() {
+        describe("in case of popup_mod", function() {
+            beforeEach(function() {
+                this.popupWithMod = nb.find('popup-with-mod');
+            });
+            afterEach(function() {
+                this.popupWithMod.destroy();
+                this.popupWithMod = null;
+            });
+
+            it("nb-popup-outer_mod should be added to jquery ui wrapper", function(done) {
+                var popup = this.popupWithMod;
+
+                popup.on('nb-opened', function() {
+                    var $wrapper = $(popup.node.widget.uiDialog);
+                    expect($wrapper.hasClass('nb-popup-outer_mod')).to.be.ok();
+                    done();
+                });
+                popup.open();
+            });
+
+            it("should have nb-popup-outer_mod after reopening", function(done) {
+                var popup = this.popupWithMod;
+                var isFirstOpen = true;
+
+                popup.on('nb-opened', function() {
+                    if (isFirstOpen) {
+                        popup.on('nb-closed', function() {
+                            isFirstOpen = false;
+                            popup.open();
+                        });
+                        popup.close();
+                    } else {
+                        var $wrapper = $(popup.node.widget.uiDialog);
+                        expect($wrapper.hasClass('nb-popup-outer_mod')).to.be.ok();
+                        done();
+                    }
+                });
+                popup.open();
+            })
+        });
+
+        describe("in case of mix with my-block__element my-block__element_mod", function() {
+            beforeEach(function() {
+                this.popupWithMix = nb.find('popup-with-mix');
+            });
+            afterEach(function() {
+                this.popupWithMix.destroy();
+                this.popupWithMix = null;
+            });
+
+            it("nb-popup-outer_mod should be added to jquery ui wrapper", function(done) {
+                var popup = this.popupWithMix;
+
+                popup.on('nb-opened', function() {
+                    var $wrapper = $(popup.node.widget.uiDialog);
+                    expect($wrapper.hasClass('nb-popup-outer_mod')).to.be.ok();
+                    done();
+                });
+                popup.open();
+            });
+
+            it("nb-popup-outer_element should not be added to jquery ui wrapper", function(done) {
+                var popup = this.popupWithMix;
+
+                popup.on('nb-opened', function() {
+                    var $wrapper = $(popup.node.widget.uiDialog);
+                    expect($wrapper.hasClass('nb-popup-outer_element')).to.not.be.ok();
+                    done();
+                });
+                popup.open();
+            });
+        });
+
+        describe("in case _global-mod", function() {
+            beforeEach(function() {
+                this.popupWithGlobal = nb.find('popup-with-global-mod');
+            });
+            afterEach(function() {
+                this.popupWithGlobal.destroy();
+                this.popupWithGlobal = null;
+            });
+
+            it("nb-popup-outer_global-mod should not be added to jquery ui wrapper", function(done) {
+                var popup = this.popupWithGlobal;
+
+                popup.on('nb-opened', function() {
+                    var $wrapper = $(popup.node.widget.uiDialog);
+                    expect($wrapper.hasClass('nb-popup-outer_global-mod')).to.not.ok();
+                    done();
+                });
+                popup.open();
+            });
+        });
+    });
+
     describe("#Toggler", function() {
         it("#Open", function() {
             this.toggler.open();

--- a/unittests/spec/popup/popup.yate
+++ b/unittests/spec/popup/popup.yate
@@ -55,6 +55,33 @@ match .popup {
     'content': 'Hello, words!'
  })
 
+ nb-popup({
+    'id': 'popup-with-mod'
+    'class': 'popup_mod'
+    'data-nb': {
+        'modal': true()
+    }
+    'content': 'Hello, words!'
+ })
+
+  nb-popup({
+    'id': 'popup-with-global-mod'
+    'class': '_global-mod'
+    'data-nb': {
+        'modal': true()
+    }
+    'content': 'Hello, words!'
+ })
+
+ nb-popup({
+    'id': 'popup-with-mix'
+    'class': 'my-block__element my-block__element_mod'
+    'data-nb': {
+        'modal': true()
+    }
+    'content': 'Hello, words!'
+ })
+
  nb-popup-menu({
     'id': 'popup-menu'
     'menu': [


### PR DESCRIPTION
- [x] тесты для прокидывания дополнительного модификатора ноде виджета, которая оборачивает попап:
  - класс должен добавляться, если был указан модификатор попапа
  - класс не должен добавляться, если у попапа есть миксы с элементами блоков
  - класс должен оставаться на месте при последующих открытиях
- [x] не добавлять лишний модификатор (поправил регулярку, которая мачилась на элемент без модификатора)
- [x] не затирать дополнительный класс после открытия (добавляли класс один раз при инициализации, а после — его уже не было)