### PR TITLE
Разломался фиксированный попап при переходе на ES6

### DIFF
--- a/blocks/popup/popup.js
+++ b/blocks/popup/popup.js
@@ -683,19 +683,19 @@
             var that = this;
             var params = params || {};
             var how = how || {};
-
             var data = this.nbdata();
+
+            if (how === 'fixed' || data.how === 'fixed') {
+                how = {fixed: true};
+            }
+
             // по умолчанию попап позиционирова абсолютно
             var isFixed = false;
 
-            // сделаем попап фиксированным, если
-            // у popup-toggler задан how.fixed = true
+            // сделаем попап фиксированным, если:
+            // - у popup-toggler задан how.fixed = true
+            // - был задан атрибут data-nb-how = 'fixed' у самого попапа
             if (how.fixed) {
-                isFixed = true;
-            }
-            // или если был задан атрибут data-nb-how = 'fixed'
-            // в настройках самого попапа
-            if (data && data.how == 'fixed') {
                 isFixed = true;
             }
 

--- a/unittests/spec/popup/popup.js
+++ b/unittests/spec/popup/popup.js
@@ -45,6 +45,39 @@ describe("Popup Tests", function() {
         });
     });
 
+    describe("Popup should be fixed", function() {
+        beforeEach(function() {
+            this.toggler1 = nb.find('popup-toggler-fixed1');
+            this.toggler2 = nb.find('popup-toggler-fixed2');
+        });
+        afterEach(function() {
+            this.toggler1.destroy();
+            this.toggler2.destroy();
+        });
+
+        it("when it`s toggler has how: 'fixed' option", function(done) {
+            var toggler = this.toggler1;
+            var popup = toggler.getPopup();
+
+            popup.on('nb-opened', function() {
+                expect(popup.$node.parent().hasClass('ui-dialog-fixed')).to.be.ok();
+                done();
+            });
+            toggler.open();
+        });
+
+        it("when it has data-nb-how attr defined as fixed", function(done) {
+            var toggler = this.toggler2;
+            var popup = toggler.getPopup();
+
+            popup.on('nb-opened', function() {
+                expect(popup.$node.parent().hasClass('ui-dialog-fixed')).to.be.ok();
+                done();
+            });
+            toggler.open();
+        });
+    });
+
     describe("Popup extra modifier", function() {
         describe("in case of popup_mod", function() {
             beforeEach(function() {

--- a/unittests/spec/popup/popup.yate
+++ b/unittests/spec/popup/popup.yate
@@ -17,6 +17,19 @@ match .popup {
         </span>
     </a>
 
+    // тогглер сам задает fixed для попапа
+    <a id="popup-toggler-fixed1" class="_init" data-nb="popup-toggler" data-nb-popup-toggler="{{id: 'popup-fixed1', appendTo: '.content', how: 'fixed'}}" href="#default">
+        <span class="link__inner">
+            "popup"
+        </span>
+    </a>
+
+    <a id="popup-toggler-fixed2" class="_init" data-nb="popup-toggler" data-nb-popup-toggler="{{id: 'popup-fixed2', appendTo: '.content'}}" href="#default">
+        <span class="link__inner">
+            "popup"
+        </span>
+    </a>
+
     // Попап, находящийся в тесном блоке, проверяется выравнивание хвостика.
     <div class="tight" style="width: 50px; height: 20px;">
         <a id="popup-toggler-tight" class="_init" data-nb="popup-toggler" data-nb-popup-toggler="{{id: 'popup-tight', appendTo: '.tight'}}" href="#default">
@@ -78,6 +91,19 @@ match .popup {
     'class': 'my-block__element my-block__element_mod'
     'data-nb': {
         'modal': true()
+    }
+    'content': 'Hello, words!'
+ })
+
+ nb-popup({
+    'id': 'popup-fixed1'
+    'content': 'Hello, words!'
+ })
+
+ nb-popup({
+    'id': 'popup-fixed2'
+    'data-nb': {
+        'how': 'fixed'
     }
     'content': 'Hello, words!'
  })


### PR DESCRIPTION
В ES6 появился метод `at` у строки.

У нас есть такой код:

```js
position: {
  at:  (how.at ? how.at : 'center bottom') 
}
```

how может быть строкой (`fixed`) — соответственно, мы берем в качестве значения position.at ссылку на функцию из прототипа `String` и все ломается.

Сделал `how` всегда объектом. В случае если это строка `fixed`, нужно просто сделать его равным `{how: 'fixed'}` — с таким объектом работает дальнейшая логика.