### PR TITLE
Adds touchstart and touchend events

### DIFF
--- a/blocks/select/select.js
+++ b/blocks/select/select.js
@@ -17,7 +17,8 @@
  */
 nb.define('select', {
         events: {
-            'mousedown': '_onclick'
+            'mousedown': '_onclick',
+            'touchstart': '_onclick'
             //'open' { event, ui}
             //'close' { event, ui}
         },

--- a/libs/nanoblocks.js
+++ b/libs/nanoblocks.js
@@ -190,7 +190,9 @@ var nb = nb || {};
         'mouseover',
         'mouseout',
         'focusin',
-        'focusout'
+        'focusout',
+        'touchstart',
+        'touchend'
     ];
 
 //  Regexp для строк вида 'click', 'click .foo'.


### PR DESCRIPTION
На мобильных логичнее использовать `touch`-ивенты. Кроме того, `mousedown` может и вовсе не работать, в сочетании, например, с fastclick-полифилом